### PR TITLE
Correct the description and components of Faithful Hound

### DIFF
--- a/dndspells/spells.json
+++ b/dndspells/spells.json
@@ -7637,7 +7637,7 @@
   },
   {
     "name": "Mordenkainen's Faithful Hound",
-    "desc": "<p>You create a sword-shaped plane of force that hovers within range. It lasts for the duration.</p><p>When the sword appears, you make a melee spell attack against a target of your choice within 5 feet of the sword. On a hit, the target takes 3d10 force damage. Until the spell ends, you can use a bonus action on each of your turns to move the sword up to 20 feet to a spot you can see and repeat this attack against the same target or a different one.</p>",
+    "desc": "<p>You conjure a phantom watchdog in an unoccupied space that you can see within range, where it remains for the duration, until you dismiss it as an action, or until you move more than 100 feet away from it.</p><p>The hound is invisible to all creatures except you and can't be harmed. When a Small or larger creature comes within 30 feet of it without first speaking the password that you specify when you cast this spell, the hound starts barking loudly. The hound sees invisible creatures and can see into the Ethereal Plane. It ignores illusions.</p><p>At the start of each of your turns, the hound attempts to bite one creature within 5 feet of it that is hostile to you. The hound's attack bonus is equal to your spellcasting ability modifier + your proficiency bonus. On a hit, it deals 4d8 piercing damage.</p>",
     "range": "30 feet",
     "ritual": false,
     "duration": "8 hours",
@@ -7655,8 +7655,8 @@
     "verbal": true,
     "material": true,
     "somatic": true,
-    "material_desc": "a miniature platinum sword with a grip and pommel of copper and zinc, worth 250gp",
-    "material_cost": true,
+    "material_desc": "a tiny silver whistle, a piece of bone, and a thread",
+    "material_cost": false,
     "source": "PHB",
     "page": 261
   },


### PR DESCRIPTION
It appears that part of this spell was duplicated from Mordenkainen's
Sword.

---

I've seen this duplication in many machine-readable versions of spell text. It might be worth checking your original source to see if there's an error.

The corrected text comes from "Faithful Hound" on page 142 of the [SRD](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf). Note that the SRD does not include the "Mordenkainen" prefix on the spell names, so it may be prudent to adjust the title. Even D&D Beyond does this: https://www.dndbeyond.com/spells/faithful-hound.

By the way, thanks for making this spellbook generator! It's super helpful and I use it all the time. :)